### PR TITLE
Add sync-args default value in action files

### DIFF
--- a/test-build-publish-with-cov/action.yml
+++ b/test-build-publish-with-cov/action.yml
@@ -12,6 +12,7 @@ inputs:
   sync-args:
     description: 'Extra arguments to pass to uv install'
     required: false
+    default: ''
   pytest-args:
     description: 'Extra arguments to pass to pytest'
     required: false

--- a/test-build-publish/action.yml
+++ b/test-build-publish/action.yml
@@ -12,6 +12,7 @@ inputs:
   sync-args:
     description: 'Extra arguments to pass to uv install'
     required: false
+    default: ''
   pytest-args:
     description: 'Extra arguments to pass to pytest'
     required: false

--- a/test-build-with-cov/action.yml
+++ b/test-build-with-cov/action.yml
@@ -12,6 +12,7 @@ inputs:
   sync-args:
     description: 'Extra arguments to pass to uv install'
     required: false
+    default: ''
   pytest-args:
     description: 'Extra arguments to pass to pytest'
     required: false

--- a/test-build/action.yml
+++ b/test-build/action.yml
@@ -12,6 +12,7 @@ inputs:
   sync-args:
     description: 'Extra arguments to pass to uv install'
     required: false
+    default: ''
   pytest-args:
     description: 'Extra arguments to pass to pytest'
     required: false

--- a/test-with-cov/action.yml
+++ b/test-with-cov/action.yml
@@ -12,6 +12,7 @@ inputs:
   sync-args:
     description: 'Extra arguments to pass to uv install'
     required: false
+    default: ''
   pytest-args:
     description: 'Extra arguments to pass to pytest'
     required: false

--- a/test/action.yml
+++ b/test/action.yml
@@ -12,6 +12,7 @@ inputs:
   sync-args:
     description: 'Additional arguments to pass to uv install'
     required: false
+    default: ''
   pytest-args:
     description: 'Extra arguments to pass to pytest'
     required: false


### PR DESCRIPTION
Add default values for `sync-args` input in action files.

* **test-build-publish-with-cov/action.yml**
  - Add a default value of an empty string for `sync-args` input.
* **test-build-publish/action.yml**
  - Add a default value of an empty string for `sync-args` input.
* **test-build-with-cov/action.yml**
  - Add a default value of an empty string for `sync-args` input.
* **test-build/action.yml**
  - Add a default value of an empty string for `sync-args` input.
* **test-with-cov/action.yml**
  - Add a default value of an empty string for `sync-args` input.
* **test/action.yml**
  - Add a default value of an empty string for `sync-args` input.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/deeprave/actions/pull/1?shareId=273d6d58-b1cf-4855-abf3-49d0b009c9ca).

## Summary by Sourcery

CI:
- Set the default value of the "sync-args" input to an empty string across all GitHub Actions.